### PR TITLE
Hide bot token from public view and access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const Telegraf = require('telegraf');
 const TelegrafFlow = require('telegraf-flow');
 const flow = new TelegrafFlow();
@@ -52,11 +53,11 @@ flow.register(new Scenes().symptomScene());
 flow.register(new Scenes().statScene());
 
 
-bot.use(Telegraf.session())
-bot.use(flow.middleware())
+bot.use(Telegraf.session());
+bot.use(flow.middleware());
 
 
 // bot.telegram.setWebhook("https://.herokuapp.com/" + process.env.BOT_TOKEN);
 // bot.startWebhook('/' + process.env.BOT_TOKEN, null, process.env.PORT)
 
-bot.launch()
+bot.launch();

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,11 @@
         "ms": "^2.1.1"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/Ethiopia-COVID19/bot#readme",
   "dependencies": {
+    "dotenv": "^8.2.0",
     "node-fetch": "^2.6.0",
     "telegraf": "^3.36.0",
     "telegraf-flow": "^8.3.0"

--- a/src/Secrets.js
+++ b/src/Secrets.js
@@ -14,10 +14,10 @@ const LOG_TITLE = "COVID19 Log";
 
 const MAIN_CHANNEL_USERNAME = "";
 
-const ADMINS = []
+const ADMINS = [];
 
 
-const BOT_TOKEN = "819778324:AAEsM_p4hZbizY3zwz75uqhQooKBaMXSjMw";
+const BOT_TOKEN = process.env.BOT_TOKEN;
 
 
 


### PR DESCRIPTION
- Exposing bot token for public would allow easy hijack of the bot. In
addition, assuming the best in everyone and we say no one will do
malicious act, it would not allow for 2 developers to run the bot at the
same time while developing.